### PR TITLE
fix single keybind trigger with modifiers

### DIFF
--- a/crates/too_events/src/event.rs
+++ b/crates/too_events/src/event.rs
@@ -141,7 +141,10 @@ impl Event {
 
     fn is_keybind(key: Key, modifiers: Modifiers, expected: impl Into<Keybind>) -> bool {
         let expected: Keybind = expected.into();
-        if matches!(expected.key, Key::Char(..)) && expected.modifiers.is_none() {
+        if matches!(expected.key, Key::Char(..))
+            && expected.modifiers.is_none()
+            && modifiers.is_none()
+        {
             return key == expected.key;
         }
         Keybind::new(key, modifiers) == expected


### PR DESCRIPTION
This fixes an unexpected behavior when you have something like this:
```rs
  if event.is_keybind_pressed('w') {
      // Do something
  }
  
  if event.is_keybind_pressed(Keybind::from('w').ctrl()) {
      // Do something else
  }
```

...and both being triggered when `ctrl-w` is pressed.