### PR TITLE
Add overlays

### DIFF
--- a/crates/too_runner/examples/anon_shape.rs
+++ b/crates/too_runner/examples/anon_shape.rs
@@ -2,10 +2,10 @@ use too_crossterm::{Config, Term};
 
 use too_runner::{
     color::Rgba,
-    math::{pos2, Rect, Vec2},
+    math::{pos2, Rect},
     pixel::Pixel,
     shapes::{anonymous, anonymous_ctx},
-    App, AppRunner, SurfaceMut,
+    App, AppRunner, Context, SurfaceMut,
 };
 
 fn main() -> std::io::Result<()> {
@@ -18,11 +18,11 @@ struct Demo {
 }
 
 impl App for Demo {
-    fn update(&mut self, dt: f32, _size: Vec2) {
+    fn update(&mut self, dt: f32, _ctx: Context<'_>) {
         self.t += 1.0 * dt * 1.0 / 2.0
     }
 
-    fn render(&mut self, mut surface: SurfaceMut<'_>) {
+    fn render(&mut self, mut surface: SurfaceMut<'_>, _ctx: Context<'_>) {
         surface
             .draw(anonymous_ctx(&self, |size| {
                 move |this, pos| match () {

--- a/crates/too_runner/examples/ddd.rs
+++ b/crates/too_runner/examples/ddd.rs
@@ -1,12 +1,13 @@
 use too_crossterm::{Config, Term};
 
+use too_renderer::SurfaceMut;
 use too_runner::{
     color::Rgba,
     events::{Event, Key, Keybind},
     math::{vec2, vec3, Pos2, Rect, Vec2, Vec3},
     pixel::Pixel,
     shapes::{Fill, Text},
-    App, AppRunner, Backend, Context, SurfaceMut,
+    App, AppRunner, Context,
 };
 
 use rayon::iter::*;
@@ -174,7 +175,7 @@ impl Demo {
         }
     }
 
-    fn event(&mut self, ev: Event, mut ctx: Context<'_, impl Backend>) {
+    fn event(&mut self, ev: Event, mut ctx: Context<'_>) {
         const SPEED: f32 = 2.0;
 
         const FORWARD: Vec3 = vec3(0.0, 0.0, SPEED);
@@ -642,19 +643,19 @@ impl Screen {
 }
 
 impl App for Demo {
-    fn initial_size(&mut self, size: Vec2) {
-        self.screen = Screen::new(size)
+    fn initial_size(&mut self, ctx: Context<'_>) {
+        self.screen = Screen::new(ctx.size())
     }
 
-    fn event(&mut self, event: Event, ctx: Context<'_, impl Backend>, _size: Vec2) {
+    fn event(&mut self, event: Event, ctx: Context<'_>) {
         self.event(event, ctx);
     }
 
-    fn update(&mut self, dt: f32, _size: Vec2) {
+    fn update(&mut self, dt: f32, _ctx: Context<'_>) {
         self.integrate(dt);
     }
 
-    fn render(&mut self, mut surface: too_renderer::SurfaceMut<'_>) {
+    fn render(&mut self, mut surface: SurfaceMut<'_>, _ctx: Context<'_>) {
         self.render_scene(&mut surface);
 
         if self.show_help {

--- a/crates/too_runner/examples/gradient.rs
+++ b/crates/too_runner/examples/gradient.rs
@@ -7,7 +7,7 @@ use too_runner::{
     math::{lerp, pos2, Pos2, Vec2},
     pixel::Pixel,
     shapes::{Shape, Text},
-    App, AppRunner, Backend, Context, SurfaceMut,
+    App, AppRunner, Context, SurfaceMut,
 };
 
 fn main() -> std::io::Result<()> {
@@ -58,7 +58,7 @@ impl Demo {
     }
 }
 impl App for Demo {
-    fn event(&mut self, event: Event, mut ctx: Context<'_, impl Backend>, _size: Vec2) {
+    fn event(&mut self, event: Event, mut ctx: Context<'_>) {
         const NEXT_GRADIENT: Keybind = Keybind::from_char('d');
         const PREV_GRADIENT: Keybind = Keybind::from_char('a');
 
@@ -98,13 +98,13 @@ impl App for Demo {
         }
     }
 
-    fn update(&mut self, dt: f32, _size: Vec2) {
+    fn update(&mut self, dt: f32, _ctx: Context<'_>) {
         self.theta += (self.up as u8 as f32 * 2.0 - 1.0) * self.duration.recip() * dt;
         self.theta = self.theta.clamp(-1.0, 1.0);
         self.up = self.up ^ (self.theta >= 1.0) ^ (self.theta <= -1.0)
     }
 
-    fn render(&mut self, mut surface: SurfaceMut) {
+    fn render(&mut self, mut surface: SurfaceMut, _ctx: Context<'_>) {
         let (label, _) = &self.gradients[self.pos];
         surface
             .draw(&*self)

--- a/crates/too_runner/examples/hello.rs
+++ b/crates/too_runner/examples/hello.rs
@@ -4,9 +4,9 @@ use too_runner::{
     color::Rgba,
     events::Event,
     layout::Align2,
-    math::{rect, vec2, Pos2, Rect, Vec2},
+    math::{rect, vec2, Pos2, Rect},
     shapes::{Fill, Text},
-    App, AppRunner, Backend, Command, Context, SurfaceMut,
+    App, AppRunner, Command, Context, SurfaceMut,
 };
 
 fn main() -> std::io::Result<()> {
@@ -48,7 +48,7 @@ impl Hello {
 }
 
 impl App for Hello {
-    fn event(&mut self, event: Event, mut ctx: Context<'_, impl Backend>, size: Vec2) {
+    fn event(&mut self, event: Event, mut ctx: Context<'_>) {
         if event.is_keybind_pressed('q') {
             ctx.command(Command::request_quit());
         }
@@ -81,7 +81,7 @@ impl App for Hello {
             if self.rect.contains(pos) {
                 self.grabbed = Grabbed::Grabbed;
                 self.rect = self.rect.translate(delta);
-                self.rect = rect(size).clamp_rect(self.rect);
+                self.rect = rect(ctx.size()).clamp_rect(self.rect);
             }
         }
 
@@ -108,14 +108,14 @@ impl App for Hello {
         }
     }
 
-    fn update(&mut self, dt: f32, _size: Vec2) {
+    fn update(&mut self, dt: f32, _ctx: Context<'_>) {
         let duration = 5.0f32;
         self.value += (self.up as u8 as f32 * 2.0 - 1.0) * duration.recip() * dt;
         self.value = self.value.clamp(0.0, 1.0);
         self.up = self.up ^ (self.value >= 1.0) ^ (self.value <= 0.0)
     }
 
-    fn render(&mut self, mut surface: SurfaceMut) {
+    fn render(&mut self, mut surface: SurfaceMut, _ctx: Context<'_>) {
         let rect = surface.rect();
         surface
             .crop(Rect::from_center_size(rect.center(), rect.size() / 3))

--- a/crates/too_runner/examples/layout.rs
+++ b/crates/too_runner/examples/layout.rs
@@ -6,7 +6,7 @@ use too_runner::{
     layout::{Anchor, Anchor2, Axis, LinearLayout},
     math::{vec2, Vec2},
     shapes::{Fill, Text},
-    App, AppRunner, Backend, Context,
+    App, AppRunner, Context, SurfaceMut,
 };
 
 fn main() -> std::io::Result<()> {
@@ -41,7 +41,7 @@ struct Demo {
 }
 
 impl App for Demo {
-    fn event(&mut self, event: Event, _ctx: Context<'_, impl Backend>, _size: Vec2) {
+    fn event(&mut self, event: Event, _ctx: Context<'_>) {
         if event.is_keybind_pressed(Key::Enter) {
             self.elements
                 .push(vec2(fastrand::i32(3..=10), fastrand::i32(3..=10)));
@@ -105,7 +105,7 @@ impl App for Demo {
         }
     }
 
-    fn render(&mut self, mut surface: too_runner::SurfaceMut) {
+    fn render(&mut self, mut surface: SurfaceMut, _ctx: Context<'_>) {
         let mut layout = LinearLayout::new(self.axis)
             .wrap(self.wrap)
             .spacing(self.spacing)

--- a/crates/too_runner/examples/overlay.rs
+++ b/crates/too_runner/examples/overlay.rs
@@ -1,0 +1,47 @@
+use color::Rgba;
+use events::Event;
+use layout::{Anchor2, Axis};
+use shapes::Fill;
+use too_crossterm::*;
+use too_math::Rect;
+use too_runner::*;
+
+fn main() -> std::io::Result<()> {
+    let term = Term::setup(Config::default())?;
+    Demo {
+        axis: Axis::Horizontal,
+        anchor: Anchor2::RIGHT_BOTTOM,
+        fg: 0.0,
+    }
+    .run(term)
+}
+
+struct Demo {
+    axis: Axis,
+    anchor: Anchor2,
+    fg: f32,
+}
+
+impl App for Demo {
+    fn update(&mut self, dt: f32, mut ctx: Context<'_>) {
+        self.fg += 1.0 * dt / 5.0_f32;
+        ctx.overlay().fps.fg = Rgba::sine(self.fg);
+    }
+
+    fn event(&mut self, event: Event, mut ctx: Context<'_>) {
+        if event.is_keybind_pressed('t') {
+            ctx.overlay().fps.anchor = self.anchor;
+            ctx.overlay().fps.axis = self.axis;
+            ctx.toggle_fps();
+        }
+    }
+
+    fn render(&mut self, mut surface: SurfaceMut, _ctx: Context<'_>) {
+        surface
+            .crop(Rect::from_center_size(
+                surface.rect().center(),
+                surface.rect().size() / 3,
+            ))
+            .draw(Fill::new("#555"));
+    }
+}

--- a/crates/too_runner/examples/torch.rs
+++ b/crates/too_runner/examples/torch.rs
@@ -7,7 +7,7 @@ use too_runner::{
     math::{lerp, pos2, Pos2, Rect, Vec2},
     pixel::Pixel,
     shapes::{Fill, Shape},
-    App, AppRunner, Backend, Context, SurfaceMut,
+    App, AppRunner, Context, SurfaceMut,
 };
 
 fn main() -> std::io::Result<()> {
@@ -111,17 +111,17 @@ impl Demo {
 }
 
 impl App for Demo {
-    fn event(&mut self, event: Event, _: Context<'_, impl Backend>, size: Vec2) {
+    fn event(&mut self, event: Event, ctx: Context<'_>) {
         if event.is_keybind_pressed(' ') {
             self.enabled = !self.enabled
         }
 
         if event.is_keybind_pressed(Key::PageDown) {
-            self.scroll_down(size.y as usize * 2);
+            self.scroll_down(ctx.size().y as usize * 2);
         }
 
         if event.is_keybind_pressed(Key::PageUp) {
-            self.scroll_up(size.y as usize * 2);
+            self.scroll_up(ctx.size().y as usize * 2);
         }
 
         if event.is_keybind_pressed(Key::Down) {
@@ -152,7 +152,7 @@ impl App for Demo {
         }
     }
 
-    fn render(&mut self, mut surface: SurfaceMut) {
+    fn render(&mut self, mut surface: SurfaceMut, _ctx: Context<'_>) {
         let offset = self.lines.len().saturating_sub(self.pos);
         let offset = offset
             .checked_sub(surface.rect().height().saturating_sub_unsigned(1) as _)

--- a/crates/too_runner/src/app.rs
+++ b/crates/too_runner/src/app.rs
@@ -1,0 +1,52 @@
+use too_events::Event;
+use too_renderer::SurfaceMut;
+
+use crate::Context;
+
+/// Trait for defining an application to run
+pub trait App {
+    /// The initial surface size that you can use to compute some internal state
+    fn initial_size(&mut self, ctx: Context<'_>) {
+        _ = ctx
+    }
+
+    /// An [`Event`] was sent from the backend
+    ///
+    /// This provides a [`Context`], and the current surface `size`
+    ///
+    /// This [`Context`] will let you send commands to the backend and configure the overlays
+    fn event(&mut self, event: Event, ctx: Context<'_>) {
+        _ = event;
+        _ = ctx;
+    }
+
+    /// Update allows you to interpolate state
+    ///
+    /// `dt` is the delta-time that can be used for interpolation
+    /// `size` is the current surface size
+    fn update(&mut self, dt: f32, ctx: Context<'_>) {
+        _ = dt;
+        _ = ctx;
+    }
+
+    /// Min UPS is the minimum UPS the runner should perform
+    ///
+    /// The default is 10 updates/s
+    fn min_ups(&self) -> f32 {
+        10.0
+    }
+
+    /// Max UPS is the maximum UPS the runner should perform
+    ///
+    /// The default is 60 updates/s
+    fn max_ups(&self) -> f32 {
+        60.0
+    }
+
+    /// Render your application
+    ///
+    /// This provides you with a [`SurfaceMut`] that allows you to draw onto
+    ///
+    /// The draw order are back-to-front. Later draw calls will be drawn over earlier calls
+    fn render(&mut self, surface: SurfaceMut, ctx: Context<'_>);
+}

--- a/crates/too_runner/src/app_runner.rs
+++ b/crates/too_runner/src/app_runner.rs
@@ -1,0 +1,80 @@
+use too_events::EventReader;
+use too_layout::LinearLayout;
+use too_math::vec2;
+use too_renderer::{Backend, SurfaceMut};
+use too_shapes::Text;
+
+use crate::{App, Overlay, Runner};
+
+/// A trait to run your application
+///
+/// It is implemented for all types that implement [`App`].
+///
+/// # Example:
+/// ```rust
+/// use too_runner::{AppRunner as _, SurfaceMut};
+///
+/// struct Demo {
+///     state: i32
+/// }
+///
+/// impl Demo {
+///     fn new(state: i32) -> Self {
+///         Self { state }
+///     }
+/// }
+///
+/// impl too_runner::App for Demo {
+///     fn render(&mut self, surface: &mut SurfaceMut) {}
+/// }
+///
+/// # fn get_backend() -> std::io::Result<too_runner::dummy::Dummy> { Ok(too_runner::dummy::Dummy) }
+/// fn main() -> std::io::Result<()> {
+///     let backend = get_backend()?;
+///     Demo::new(1234).run(backend)
+/// }
+/// ```
+pub trait AppRunner: App + Sealed + Sized {
+    /// Run the [`App`] with the provided [`Backend`] and [`EventReader`]
+    fn run(self, term: impl Backend + EventReader) -> std::io::Result<()> {
+        Runner::new()
+            .min_ups(Self::min_ups)
+            .max_ups(Self::max_ups)
+            .init(Self::initial_size)
+            .event(Self::event)
+            .update(Self::update)
+            .render(Self::render)
+            .post_render(draw_default_overlay)
+            .run(self, term)
+    }
+}
+
+fn draw_default_overlay(_: &mut impl App, overlay: &mut Overlay, mut surface: SurfaceMut<'_>) {
+    if overlay.fps.show {
+        let frame_stats = overlay.fps.get_current_stats();
+
+        let mut alloc = LinearLayout::new(overlay.fps.axis)
+            .anchor(overlay.fps.anchor)
+            .wrap(true)
+            .spacing(vec2(1, 0))
+            .layout(surface.rect());
+
+        let (fg, bg) = (overlay.fps.fg, overlay.fps.bg);
+        for part in [
+            format!("min: {:.2}", frame_stats.min),
+            format!("max: {:.2}", frame_stats.max),
+            format!("avg: {:.2}", frame_stats.avg),
+        ] {
+            let part = Text::new(part).fg(fg).bg(bg);
+            if let Some(rect) = alloc.allocate(part.size()) {
+                surface.crop(rect).draw(part);
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+pub trait Sealed {}
+
+impl<T> Sealed for T {}
+impl<T: App + Sealed> AppRunner for T {}

--- a/crates/too_runner/src/context.rs
+++ b/crates/too_runner/src/context.rs
@@ -1,0 +1,39 @@
+use std::collections::VecDeque;
+
+use too_math::Vec2;
+use too_renderer::Command;
+
+use crate::Overlay;
+
+/// Provides the ability to send [`Command`] to the backend and access to the [`Overlay`]
+pub struct Context<'a> {
+    pub(crate) overlay: &'a mut Overlay,
+    pub(crate) commands: &'a mut VecDeque<Command>,
+    pub(crate) size: Vec2,
+}
+
+impl<'a> Context<'a> {
+    /// Send a [`Command`] to the backend
+    ///
+    /// Commands are things like:
+    /// * Quit
+    /// * Set the title
+    pub fn command(&mut self, cmd: Command) {
+        self.commands.push_back(cmd);
+    }
+
+    /// The overlay
+    pub fn overlay(&mut self) -> &mut Overlay {
+        self.overlay
+    }
+
+    /// Current size of the terminal screen
+    pub fn size(&self) -> Vec2 {
+        self.size
+    }
+
+    /// Toggle the FPS overlay
+    pub fn toggle_fps(&mut self) {
+        self.overlay.fps.show = !self.overlay.fps.show
+    }
+}

--- a/crates/too_runner/src/ema_window.rs
+++ b/crates/too_runner/src/ema_window.rs
@@ -1,3 +1,4 @@
+/// Stats for an [`EmaWindow`]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 pub struct WindowStats {
     pub min: f32,
@@ -5,6 +6,9 @@ pub struct WindowStats {
     pub avg: f32,
 }
 
+/// A rolling window that utlizies [Exponential smoothing](https://en.wikipedia.org/wiki/Exponential_smoothing)
+///
+/// ***NOTE*** the buffer size `N` must be a power of 2
 pub struct EmaWindow<const N: usize> {
     alpha: f32,
     ema: f32,
@@ -18,6 +22,11 @@ impl<const N: usize> Default for EmaWindow<N> {
 }
 
 impl<const N: usize> EmaWindow<N> {
+    /// Create a new [`EmaWindow`]
+    ///
+    /// This uses an alpha value of 1.0 for 'total' smoothness
+    ///
+    /// ***NOTE*** the buffer size `N` must be a power of 2
     pub const fn new() -> Self {
         Self {
             alpha: const { 1.0 / N as f32 },
@@ -26,11 +35,13 @@ impl<const N: usize> EmaWindow<N> {
         }
     }
 
+    /// Push a value into the window
     pub fn push(&mut self, val: f32) {
         self.ema = self.ema + self.alpha * (val - self.ema);
         self.min_max.push(val);
     }
 
+    /// Get the current stats of the window
     pub fn get(&self) -> WindowStats {
         let (min, max) = self.min_max.min_max();
         WindowStats {

--- a/crates/too_runner/src/lib.rs
+++ b/crates/too_runner/src/lib.rs
@@ -1,12 +1,5 @@
-use std::time::{Duration, Instant};
-
-use too_events::Event;
-use too_math::Vec2;
-use too_renderer::TermRenderer;
-use too_shapes::Text;
-
 mod ema_window;
-pub use ema_window::EmaWindow;
+pub use ema_window::{EmaWindow, WindowStats};
 
 pub use too_renderer::{Backend, Command, SurfaceMut};
 
@@ -15,7 +8,7 @@ pub mod color {
     pub use too_renderer::{Gradient, Rgba};
 }
 
-/// Pixels are what a Surface is consists of
+/// Pixels are what a Surface consists of
 pub mod pixel {
     pub use too_renderer::{Attribute, Color, Pixel};
 }
@@ -43,290 +36,20 @@ pub mod shapes {
     pub use too_shapes::*;
 }
 
-/// Trait for defining an application to run
-pub trait App {
-    /// The initial surface size that you can use to compute some internal state
-    fn initial_size(&mut self, size: Vec2) {
-        _ = size
-    }
+mod app;
+pub use app::App;
 
-    /// An [`Event`] was sent from the backend
-    ///
-    /// This provides a [`Context`] to the backend, and the current surface `size`
-    fn event(&mut self, event: Event, ctx: Context<'_, impl Backend>, size: Vec2) {
-        _ = event;
-        _ = ctx;
-        _ = size;
-    }
+mod context;
+pub use context::Context;
 
-    /// Update allows you to interpolate state
-    ///
-    /// `dt` is the delta-time that can be used for interpolation
-    /// `size` is the current surface size
-    fn update(&mut self, dt: f32, size: Vec2) {
-        _ = dt;
-        _ = size;
-    }
+mod app_runner;
+pub use app_runner::AppRunner;
 
-    /// Min UPS is the minimum UPS the runner should perform
-    ///
-    /// The default is 10 updates/s
-    fn min_ups(&self) -> f32 {
-        10.0
-    }
+mod runner;
+pub use runner::Runner;
 
-    /// Max UPS is the maximum UPS the runner should perform
-    ///
-    /// The default is 60 updates/s
-    fn max_ups(&self) -> f32 {
-        60.0
-    }
-
-    /// Render your application
-    ///
-    /// This provides you with a [`SurfaceMut`] that allows you to draw onto
-    ///
-    /// The draw order are back-to-front. Later draw calls will be drawn over earlier calls
-    fn render(&mut self, surface: SurfaceMut);
-}
-
-/// Context to the [`Backend`] for use during [`App::event`]
-///
-/// This allows you to communicate with the backend when it sends an event
-pub struct Context<'a, B: Backend> {
-    show_fps: &'a mut bool,
-    backend: &'a mut B,
-}
-
-impl<'a, B: Backend> Context<'a, B> {
-    /// Should we show the FPS overlay?
-    pub fn show_fps(&mut self, show_fps: bool) {
-        *self.show_fps = show_fps
-    }
-
-    /// Toggle the FPS overlay
-    pub fn toggle_fps(&mut self) {
-        *self.show_fps = !*self.show_fps
-    }
-
-    /// Send a [`Command`] to the backend
-    ///
-    /// Commands are things like:
-    /// * Quit
-    /// * Set the title
-    pub fn command(&mut self, cmd: Command) {
-        self.backend.command(cmd);
-    }
-}
-
-/// A trait to run your application
-///
-/// It is implemented for all types that implement [`App`].
-///
-/// # Example:
-/// ```rust
-/// use too_runner::{AppRunner as _, SurfaceMut};
-///
-/// struct Demo {
-///     state: i32
-/// }
-///
-/// impl Demo {
-///     fn new(state: i32) -> Self {
-///         Self { state }
-///     }
-/// }
-///
-/// impl too_runner::App for Demo {
-///     fn render(&mut self, surface: &mut SurfaceMut) {}
-/// }
-///
-/// # fn get_backend() -> std::io::Result<too_runner::dummy::Dummy> { Ok(too_runner::dummy::Dummy) }
-/// fn main() -> std::io::Result<()> {
-///     let backend = get_backend()?;
-///     Demo::new(1234).run(backend)
-/// }
-/// ```
-pub trait AppRunner: App + Sealed + Sized {
-    /// Run the [`App`] with the provided [`Backend`] and [`EventReader`]
-    fn run(self, term: impl Backend + EventReader) -> std::io::Result<()> {
-        Runner::new()
-            .min_ups(Self::min_ups)
-            .max_ups(Self::max_ups)
-            .init(Self::initial_size)
-            .event(Self::event)
-            .update(Self::update)
-            .render(Self::render)
-            .run(self, term)
-    }
-}
-
-#[doc(hidden)]
-pub trait Sealed {}
-
-impl<T> Sealed for T {}
-impl<T: App + Sealed> AppRunner for T {}
-
-/// Configurable type to 'hook' into different steps of the run loop
-pub struct Runner<T, B: Backend> {
-    frame_ready: fn(&mut T),
-    min_ups: fn(&T) -> f32,
-    max_ups: fn(&T) -> f32,
-    init: fn(&mut T, Vec2),
-    event: fn(&mut T, Event, Context<'_, B>, Vec2),
-    update: fn(&mut T, f32, Vec2),
-    render: for<'c> fn(&mut T, SurfaceMut<'c>),
-}
-
-impl<T, B: Backend + EventReader> Default for Runner<T, B> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T, B: Backend + EventReader> Runner<T, B> {
-    pub const fn new() -> Self {
-        Self {
-            frame_ready: |_| {},
-            min_ups: |_| 10.0,
-            max_ups: |_| 60.0,
-            init: |_, _| {},
-            event: |_, _, _, _| {},
-            update: |_, _, _| {},
-            render: |_, _| {},
-        }
-    }
-
-    /// After updating and before rendering, this is called
-    pub const fn frame_ready(mut self, ready: fn(&mut T)) -> Self {
-        self.frame_ready = ready;
-        self
-    }
-
-    pub const fn min_ups(mut self, min_ups: fn(&T) -> f32) -> Self {
-        self.min_ups = min_ups;
-        self
-    }
-
-    pub const fn max_ups(mut self, max_ups: fn(&T) -> f32) -> Self {
-        self.max_ups = max_ups;
-        self
-    }
-
-    pub const fn init(mut self, init: fn(&mut T, Vec2)) -> Self {
-        self.init = init;
-        self
-    }
-
-    pub const fn event(mut self, event: fn(&mut T, Event, Context<'_, B>, Vec2)) -> Self {
-        self.event = event;
-        self
-    }
-
-    pub const fn update(mut self, update: fn(&mut T, f32, Vec2)) -> Self {
-        self.update = update;
-        self
-    }
-
-    // this needs a HRTB
-    pub const fn render(mut self, render: for<'c> fn(&mut T, SurfaceMut<'c>)) -> Self {
-        self.render = render;
-        self
-    }
-
-    pub fn run(self, mut state: T, mut term: B) -> std::io::Result<()> {
-        let mut surface = too_renderer::Surface::new(term.size());
-        (self.init)(&mut state, surface.rect().size());
-
-        let mut target_ups = (self.max_ups)(&state);
-        let mut base_target = Duration::from_secs_f32(1.0 / target_ups);
-        let mut fps = <EmaWindow<32>>::new();
-        let mut prev = Instant::now();
-
-        let mut show_fps = false;
-
-        loop {
-            let frame_start = Instant::now();
-
-            let mut event_dur = Duration::ZERO;
-            while let Some(ev) = term.try_read_event() {
-                if ev.is_quit() {
-                    return Ok(());
-                }
-
-                let start = Instant::now();
-                surface.update(&ev);
-                let ctx = Context {
-                    show_fps: &mut show_fps,
-                    backend: &mut term,
-                };
-                (self.event)(&mut state, ev, ctx, surface.rect().size());
-                event_dur += start.elapsed();
-
-                // only spend up to half of the budget on reading events
-                if event_dur >= base_target / 2 {
-                    break;
-                }
-            }
-
-            let mut accum = frame_start.duration_since(prev).as_secs_f32();
-            let target_dur = base_target.as_secs_f32();
-            while accum >= target_dur {
-                let start = Instant::now();
-                (self.update)(&mut state, target_dur, surface.rect().size());
-                let update_dur = start.elapsed().as_secs_f32();
-                accum -= target_dur;
-
-                target_ups = if update_dur > target_dur {
-                    (target_ups * 0.9).max((self.min_ups)(&state))
-                } else {
-                    (target_ups * 10.05).min((self.max_ups)(&state))
-                }
-            }
-
-            // and if we have any remaining from the time slice, do it again
-            if accum > 0.0 {
-                let start = Instant::now();
-                (self.update)(&mut state, accum, surface.rect().size());
-                let update_dur = start.elapsed().as_secs_f32();
-                target_ups = if update_dur > target_dur {
-                    (target_ups * 0.9).max((self.min_ups)(&state))
-                } else {
-                    (target_ups * 10.05).min((self.max_ups)(&state))
-                }
-            }
-
-            (self.frame_ready)(&mut state);
-
-            if term.should_draw() {
-                (self.render)(&mut state, surface.crop(surface.rect()));
-
-                if show_fps {
-                    let frame_stats = fps.get();
-                    let label = format!(
-                        "min: {:.2}, max: {:.2}, avg: {:.2}",
-                        frame_stats.min, frame_stats.max, frame_stats.avg,
-                    );
-                    surface.draw(Text::new(label).fg("#F00").bg("#000"));
-                }
-                surface.render(&mut TermRenderer::new(&mut term))?;
-            }
-
-            let total = frame_start.elapsed() - event_dur;
-            if let Some(sleep) = base_target
-                .checked_sub(total)
-                .filter(|&d| d > Duration::ZERO)
-            {
-                std::thread::sleep(sleep);
-            }
-
-            fps.push(frame_start.duration_since(prev).as_secs_f32());
-
-            prev = frame_start;
-            base_target = Duration::from_secs_f32(1.0 / target_ups)
-        }
-    }
-}
+mod overlay;
+pub use overlay::{FpsOverlay, Overlay};
 
 // Hide this from the docs
 // #[cfg(doctests)] doesn't work as expected here

--- a/crates/too_runner/src/overlay.rs
+++ b/crates/too_runner/src/overlay.rs
@@ -1,0 +1,51 @@
+use too_layout::{Anchor2, Axis};
+use too_renderer::Rgba;
+
+use crate::{ema_window::WindowStats, EmaWindow};
+
+#[derive(Default)] // don't mem swap me
+#[non_exhaustive]
+/// Overlays are drawn ontop of all over renders
+///
+/// These are things like an ***FPS*** display
+pub struct Overlay {
+    /// An FPS overlay
+    pub fps: FpsOverlay,
+}
+
+/// An FPS overlay
+pub struct FpsOverlay {
+    /// Should we show this overlay?
+    pub show: bool,
+    /// What axis should it be rendered on
+    pub axis: Axis,
+    /// Where should the elements be anchored on the axis
+    pub anchor: Anchor2,
+
+    /// Foreground color over the text
+    pub fg: Rgba,
+    /// Background color over the text
+    pub bg: Rgba,
+
+    pub(crate) window: EmaWindow<32>,
+}
+
+impl FpsOverlay {
+    /// Get the current [`WindowStats`] of the EMA window
+    pub fn get_current_stats(&self) -> WindowStats {
+        self.window.get()
+    }
+}
+
+impl Default for FpsOverlay {
+    fn default() -> Self {
+        Self {
+            show: false,
+            window: EmaWindow::new(),
+            axis: Axis::Horizontal,
+            anchor: Anchor2::LEFT_TOP,
+            fg: Rgba::from_static("#F00"),
+            bg: Rgba::from_static("#000"),
+        }
+    }
+}

--- a/crates/too_runner/src/runner.rs
+++ b/crates/too_runner/src/runner.rs
@@ -1,0 +1,201 @@
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use too_events::{Event, EventReader};
+use too_renderer::{Backend, SurfaceMut, TermRenderer};
+
+use crate::{overlay::Overlay, Context};
+
+/// Configurable type to 'hook' into different steps of the run loop
+pub struct Runner<T> {
+    frame_ready: fn(&mut T),
+    min_ups: fn(&T) -> f32,
+    max_ups: fn(&T) -> f32,
+    init: fn(&mut T, Context<'_>),
+    event: fn(&mut T, Event, Context<'_>),
+    update: fn(&mut T, f32, Context<'_>),
+    render: for<'c> fn(&mut T, SurfaceMut<'c>, Context<'_>),
+    post_render: for<'c> fn(&mut T, overlay: &mut Overlay, SurfaceMut<'c>),
+}
+
+impl<T> Default for Runner<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Runner<T> {
+    pub const fn new() -> Self {
+        Self {
+            frame_ready: |_| {},
+            min_ups: |_| 10.0,
+            max_ups: |_| 60.0,
+            init: |_, _| {},
+            event: |_, _, _| {},
+            update: |_, _, _| {},
+            render: |_, _, _| {},
+            post_render: |_, _, _| {},
+        }
+    }
+
+    /// After updating and before rendering, this is called
+    pub const fn frame_ready(mut self, ready: fn(&mut T)) -> Self {
+        self.frame_ready = ready;
+        self
+    }
+
+    pub const fn min_ups(mut self, min_ups: fn(&T) -> f32) -> Self {
+        self.min_ups = min_ups;
+        self
+    }
+
+    pub const fn max_ups(mut self, max_ups: fn(&T) -> f32) -> Self {
+        self.max_ups = max_ups;
+        self
+    }
+
+    pub const fn init(mut self, init: fn(&mut T, Context<'_>)) -> Self {
+        self.init = init;
+        self
+    }
+
+    pub const fn event(mut self, event: fn(&mut T, Event, Context<'_>)) -> Self {
+        self.event = event;
+        self
+    }
+
+    pub const fn update(mut self, update: fn(&mut T, f32, Context<'_>)) -> Self {
+        self.update = update;
+        self
+    }
+
+    pub const fn render(mut self, render: for<'c> fn(&mut T, SurfaceMut<'c>, Context<'_>)) -> Self {
+        self.render = render;
+        self
+    }
+
+    pub const fn post_render(
+        mut self,
+        post_render: for<'c> fn(&mut T, &mut Overlay, SurfaceMut<'c>),
+    ) -> Self {
+        self.post_render = post_render;
+        self
+    }
+
+    pub fn run(self, mut state: T, mut term: impl Backend + EventReader) -> std::io::Result<()> {
+        let mut overlay = Overlay::default();
+        let mut commands = VecDeque::new();
+
+        let mut surface = too_renderer::Surface::new(term.size());
+        (self.init)(
+            &mut state,
+            Context {
+                overlay: &mut overlay,
+                commands: &mut commands,
+                size: surface.rect().size(),
+            },
+        );
+
+        let mut target_ups = (self.max_ups)(&state);
+        let mut base_target = Duration::from_secs_f32(1.0 / target_ups);
+        let mut prev = Instant::now();
+
+        loop {
+            let frame_start = Instant::now();
+
+            let mut event_dur = Duration::ZERO;
+            while let Some(ev) = term.try_read_event() {
+                if ev.is_quit() {
+                    return Ok(());
+                }
+
+                let start = Instant::now();
+                surface.update(&ev);
+                let ctx = Context {
+                    overlay: &mut overlay,
+                    commands: &mut commands,
+                    size: surface.rect().size(),
+                };
+                (self.event)(&mut state, ev, ctx);
+                event_dur += start.elapsed();
+
+                // only spend up to half of the budget on reading events
+                if event_dur >= base_target / 2 {
+                    break;
+                }
+            }
+
+            for cmd in commands.drain(..) {
+                term.command(cmd);
+            }
+
+            let mut accum = frame_start.duration_since(prev).as_secs_f32();
+            let target_dur = base_target.as_secs_f32();
+            while accum >= target_dur {
+                let start = Instant::now();
+                let ctx = Context {
+                    overlay: &mut overlay,
+                    commands: &mut commands,
+                    size: surface.rect().size(),
+                };
+                (self.update)(&mut state, target_dur, ctx);
+                let update_dur = start.elapsed().as_secs_f32();
+                accum -= target_dur;
+
+                target_ups = if update_dur > target_dur {
+                    (target_ups * 0.9).max((self.min_ups)(&state))
+                } else {
+                    (target_ups * 10.05).min((self.max_ups)(&state))
+                }
+            }
+
+            // and if we have any remaining from the time slice, do it again
+            if accum > 0.0 {
+                let start = Instant::now();
+                let ctx = Context {
+                    overlay: &mut overlay,
+                    commands: &mut commands,
+                    size: surface.rect().size(),
+                };
+                (self.update)(&mut state, accum, ctx);
+                let update_dur = start.elapsed().as_secs_f32();
+                target_ups = if update_dur > target_dur {
+                    (target_ups * 0.9).max((self.min_ups)(&state))
+                } else {
+                    (target_ups * 10.05).min((self.max_ups)(&state))
+                }
+            }
+
+            (self.frame_ready)(&mut state);
+
+            if term.should_draw() {
+                let ctx = Context {
+                    overlay: &mut overlay,
+                    commands: &mut commands,
+                    size: surface.rect().size(),
+                };
+                (self.render)(&mut state, surface.crop(surface.rect()), ctx);
+                (self.post_render)(&mut state, &mut overlay, surface.crop(surface.rect()));
+                surface.render(&mut TermRenderer::new(&mut term))?;
+            }
+
+            let total = frame_start.elapsed() - event_dur;
+            if let Some(sleep) = base_target
+                .checked_sub(total)
+                .filter(|&d| d > Duration::ZERO)
+            {
+                std::thread::sleep(sleep);
+            }
+
+            overlay
+                .fps
+                .window
+                .push(frame_start.duration_since(prev).as_secs_f32());
+
+            prev = frame_start;
+            base_target = Duration::from_secs_f32(1.0 / target_ups)
+        }
+    }
+}

--- a/crates/too_view/src/app.rs
+++ b/crates/too_view/src/app.rs
@@ -22,18 +22,17 @@ pub trait AppRunner: App {
             view: Self::view,
         };
 
-        <Runner<Wrapper<Self>, _>>::new()
+        <Runner<Wrapper<Self>>>::new()
             .frame_ready(|wrapper| {
                 wrapper.ui.scope(&mut wrapper.app, wrapper.view);
             })
-            .update(|wrapper, dt, _size| {
+            .update(|wrapper, dt, _ctx| {
                 wrapper.ui.tick(dt);
             })
-            .event(|wrapper, ev, _ctx, _size| {
-                // TODO what to do with `ctx`;
+            .event(|wrapper, ev, _ctx| {
                 wrapper.ui.event(&mut wrapper.app, ev);
             })
-            .render(|wrapper, surface| {
+            .render(|wrapper, surface, _ctx| {
                 wrapper.ui.render(&mut wrapper.app, surface);
             })
             .run(wrapper, backend)


### PR DESCRIPTION
This requires a little refactor of all too_runner::Apps to accept Context everywhere

Because Context is passed to each App method, the sizes are now on it.

Overlays are things like `fps` which can now be configured via `ctx.overlays()`

This closes #17.