### PR TITLE
make the whole thing possibly maybe send+sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "compact_str",
  "crossterm",
  "flume",
+ "parking_lot",
  "profiling",
  "slotmap",
  "str_indices",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 [features]
 default = [ "terminal" ]
 terminal = [ "dep:crossterm", "dep:flume" ]
-profile = [ "dep:profiling", "profiling/profile-with-puffin" ]
+profile = [ "dep:profiling", "profiling/profile-with-puffin" ] # TODO don't limit the crate to just puffins
+sync = [ "dep:parking_lot" ]
 
 [dependencies]
 compact_str = "0.8.0"
@@ -25,3 +26,4 @@ flume = { version = "0.11.1", default-features = false, optional = true }
 crossterm = { version = "0.28.1", default-features = false, features = [ "events", "windows" ], optional = true }
 
 profiling = { version = "1.0.16", optional = true }
+parking_lot = { version = "0.12.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,588 @@ pub mod views;
 mod rasterizer;
 pub use rasterizer::{Rasterizer, Shape, TextShape};
 
+pub mod lock {
+    #[cfg(not(feature = "sync"))]
+    mod unsync {
+        use std::{
+            cell::RefCell,
+            fmt::Debug,
+            ops::{Deref, DerefMut},
+            rc::Rc,
+        };
+
+        #[derive(Clone, Default)]
+        pub struct Shared<T>
+        where
+            T: ?Sized,
+        {
+            inner: Rc<T>,
+        }
+
+        impl<T> Deref for Shared<T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<T: std::fmt::Debug> Debug for Shared<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.inner.fmt(f)
+            }
+        }
+
+        impl<T> Shared<T> {
+            pub fn new(value: T) -> Self {
+                Self {
+                    inner: Rc::new(value),
+                }
+            }
+
+            #[allow(clippy::should_implement_trait)]
+            pub fn clone(this: &Self) -> Self {
+                Self {
+                    inner: Rc::clone(&this.inner),
+                }
+            }
+        }
+
+        pub struct Ref<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: std::cell::Ref<'a, T>,
+        }
+
+        impl<'a, T: Debug> Debug for Ref<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for Ref<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        pub struct RefMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: std::cell::Ref<'a, T>,
+        }
+
+        impl<'a, T> RefMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&T) -> &U) -> RefMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMapped {
+                    inner: std::cell::Ref::map(this.inner, map),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&T) -> Option<&U>,
+            ) -> Option<RefMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                std::cell::Ref::filter_map(this.inner, map)
+                    .map(|inner| RefMapped { inner })
+                    .ok()
+            }
+        }
+
+        impl<'a, T: Debug> Debug for RefMapped<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMapped<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> Ref<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&T) -> &U) -> RefMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMapped {
+                    inner: std::cell::Ref::map(this.inner, map),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&T) -> Option<&U>,
+            ) -> Option<RefMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                std::cell::Ref::filter_map(this.inner, map)
+                    .map(|inner| RefMapped { inner })
+                    .ok()
+            }
+        }
+
+        pub struct RefMut<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: std::cell::RefMut<'a, T>,
+        }
+
+        impl<'a, T: Debug> Debug for RefMut<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMut<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> DerefMut for RefMut<'a, T> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.inner.deref_mut()
+            }
+        }
+
+        pub struct RefMutMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: std::cell::RefMut<'a, T>,
+        }
+
+        impl<'a, T> RefMutMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&mut T) -> &mut U) -> RefMutMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMutMapped {
+                    inner: std::cell::RefMut::map(this.inner, map),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&mut T) -> Option<&mut U>,
+            ) -> Option<RefMutMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                std::cell::RefMut::filter_map(this.inner, map)
+                    .map(|inner| RefMutMapped { inner })
+                    .ok()
+            }
+        }
+
+        impl<'a, T: Debug> Debug for RefMutMapped<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMutMapped<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> DerefMut for RefMutMapped<'a, T> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.inner.deref_mut()
+            }
+        }
+
+        impl<'a, T> RefMut<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&mut T) -> &mut U) -> RefMutMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMutMapped {
+                    inner: std::cell::RefMut::map(this.inner, map),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&mut T) -> Option<&mut U>,
+            ) -> Option<RefMutMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                std::cell::RefMut::filter_map(this.inner, map)
+                    .map(|inner| RefMutMapped { inner })
+                    .ok()
+            }
+        }
+
+        #[derive(Default)]
+        pub struct Lock<T>
+        where
+            T: ?Sized,
+        {
+            inner: RefCell<T>,
+        }
+
+        impl<T: Debug> Debug for Lock<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("Lock")
+                    .field("inner", &*self.inner.borrow())
+                    .finish()
+            }
+        }
+
+        impl<T> Lock<T> {
+            pub const fn new(value: T) -> Self {
+                Self {
+                    inner: RefCell::new(value),
+                }
+            }
+
+            pub fn borrow(&self) -> Ref<'_, T> {
+                Ref {
+                    inner: self.inner.borrow(),
+                }
+            }
+
+            pub fn borrow_mut(&self) -> RefMut<'_, T> {
+                RefMut {
+                    inner: self.inner.borrow_mut(),
+                }
+            }
+
+            pub fn get_mut(&mut self) -> &mut T {
+                self.inner.get_mut()
+            }
+
+            pub fn into_inner(self) -> T {
+                self.inner.into_inner()
+            }
+        }
+    }
+
+    #[cfg(feature = "sync")]
+    mod sync {
+        use std::{
+            fmt::Debug,
+            ops::{Deref, DerefMut},
+            sync::Arc,
+        };
+
+        // TODO determine if we're read-heavy and switch to RwLock if we are
+        use parking_lot::{
+            MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard,
+            RwLockWriteGuard,
+        };
+
+        #[derive(Clone, Default)]
+        pub struct Shared<T>
+        where
+            T: ?Sized,
+        {
+            inner: Arc<T>,
+        }
+
+        impl<T> Deref for Shared<T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<T: std::fmt::Debug> Debug for Shared<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.inner.fmt(f)
+            }
+        }
+
+        impl<T> Shared<T> {
+            pub fn new(value: T) -> Self {
+                Self {
+                    inner: Arc::new(value),
+                }
+            }
+
+            #[allow(clippy::should_implement_trait)]
+            pub fn clone(this: &Self) -> Self {
+                Self {
+                    inner: Arc::clone(&this.inner),
+                }
+            }
+        }
+
+        pub struct Ref<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: RwLockReadGuard<'a, T>,
+        }
+
+        impl<'a, T: Debug> Debug for Ref<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for Ref<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        pub struct RefMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: MappedRwLockReadGuard<'a, T>,
+        }
+
+        impl<'a, T> RefMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&T) -> &U) -> RefMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMapped {
+                    inner: MappedRwLockReadGuard::map(this.inner, |inner| map(inner)),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&T) -> Option<&U>,
+            ) -> Option<RefMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                MappedRwLockReadGuard::try_map(this.inner, map)
+                    .map(|inner| RefMapped { inner })
+                    .ok()
+            }
+        }
+
+        impl<'a, T: Debug> Debug for RefMapped<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMapped<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> Ref<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&T) -> &U) -> RefMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMapped {
+                    inner: RwLockReadGuard::map(this.inner, |inner| map(inner)),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&T) -> Option<&U>,
+            ) -> Option<RefMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                RwLockReadGuard::try_map(this.inner, map)
+                    .map(|inner| RefMapped { inner })
+                    .ok()
+            }
+        }
+
+        pub struct RefMut<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: RwLockWriteGuard<'a, T>,
+        }
+
+        impl<'a, T: Debug> Debug for RefMut<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMut<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> DerefMut for RefMut<'a, T> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.inner.deref_mut()
+            }
+        }
+
+        impl<'a, T> RefMut<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&mut T) -> &mut U) -> RefMutMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMutMapped {
+                    inner: RwLockWriteGuard::map(this.inner, |inner| map(inner)),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&mut T) -> Option<&mut U>,
+            ) -> Option<RefMutMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                RwLockWriteGuard::try_map(this.inner, map)
+                    .map(|inner| RefMutMapped { inner })
+                    .ok()
+            }
+        }
+
+        pub struct RefMutMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            inner: MappedRwLockWriteGuard<'a, T>,
+        }
+
+        impl<'a, T> RefMutMapped<'a, T>
+        where
+            T: ?Sized,
+        {
+            pub fn map<U>(this: Self, map: impl FnOnce(&mut T) -> &mut U) -> RefMutMapped<'a, U>
+            where
+                U: ?Sized,
+            {
+                RefMutMapped {
+                    inner: MappedRwLockWriteGuard::map(this.inner, |inner| map(inner)),
+                }
+            }
+
+            pub fn filter_map<U>(
+                this: Self,
+                map: impl FnOnce(&mut T) -> Option<&mut U>,
+            ) -> Option<RefMutMapped<'a, U>>
+            where
+                U: ?Sized,
+            {
+                MappedRwLockWriteGuard::try_map(this.inner, map)
+                    .map(|inner| RefMutMapped { inner })
+                    .ok()
+            }
+        }
+
+        impl<'a, T: Debug> Debug for RefMutMapped<'a, T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                (*self.inner).fmt(f)
+            }
+        }
+
+        impl<'a, T> Deref for RefMutMapped<'a, T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                self.inner.deref()
+            }
+        }
+
+        impl<'a, T> DerefMut for RefMutMapped<'a, T> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.inner.deref_mut()
+            }
+        }
+
+        #[derive(Default)]
+        pub struct Lock<T> {
+            inner: RwLock<T>,
+        }
+
+        impl<T: Debug> Debug for Lock<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("Lock")
+                    .field("inner", &*self.inner.read())
+                    .finish()
+            }
+        }
+
+        impl<T> Lock<T> {
+            pub const fn new(value: T) -> Self {
+                Self {
+                    inner: RwLock::new(value),
+                }
+            }
+
+            pub fn borrow(&self) -> Ref<'_, T> {
+                Ref {
+                    inner: self.inner.read(),
+                }
+            }
+
+            pub fn borrow_mut(&self) -> RefMut<'_, T> {
+                RefMut {
+                    inner: self.inner.write(),
+                }
+            }
+
+            pub fn get_mut(&mut self) -> &mut T {
+                self.inner.get_mut()
+            }
+
+            pub fn into_inner(self) -> T {
+                self.inner.into_inner()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "sync"))]
+    pub use unsync::*;
+
+    #[cfg(feature = "sync")]
+    pub use sync::*;
+}
+
 // TODO get rid of this
 use crate::math::Size;
 #[inline(always)]
@@ -152,8 +734,8 @@ pub fn application<R: 'static>(
     let mut surface = Surface::new(term.size());
 
     let mut state = State::new(config.palette, config.animation);
-    state.set_debug_mode(config.debug);
-    state.set_debug_anchor(config.debug_anchor);
+    view::Debug::set_debug_mode(config.debug);
+    view::Debug::set_debug_anchor(config.debug_anchor);
 
     let target = Duration::from_secs_f32(1.0 / config.fps.max(1.0));
     let max_budget = (target / 2).max(Duration::from_millis(1));

--- a/src/view/builder.rs
+++ b/src/view/builder.rs
@@ -28,8 +28,18 @@ pub trait ViewExt<'v>: Builder<'v> {
 
 impl<'v, T> ViewExt<'v> for T where T: Builder<'v> {}
 
+#[cfg(not(feature = "sync"))]
+pub trait ViewMarker {}
+#[cfg(not(feature = "sync"))]
+impl<T> ViewMarker for T {}
+
+#[cfg(feature = "sync")]
+pub trait ViewMarker: Send + Sync {}
+#[cfg(feature = "sync")]
+impl<T: Send + Sync> ViewMarker for T {}
+
 #[allow(unused_variables)]
-pub trait View: Sized + 'static + std::fmt::Debug {
+pub trait View: Sized + 'static + std::fmt::Debug + ViewMarker {
     type Args<'v>;
     type Response: 'static + Default;
 

--- a/src/view/erased.rs
+++ b/src/view/erased.rs
@@ -3,9 +3,12 @@ use crate::{
     math::{Size, Space},
 };
 
-use super::{EventCtx, Handled, Interest, IntrinsicSize, Layout, Render, View, ViewEvent};
+use super::{
+    builder::ViewMarker, EventCtx, Handled, Interest, IntrinsicSize, Layout, Render, View,
+    ViewEvent,
+};
 
-pub trait Erased: std::any::Any + std::fmt::Debug {
+pub trait Erased: std::any::Any + std::fmt::Debug + ViewMarker {
     fn interests(&self) -> Interest;
 
     fn flex(&self) -> Flex;
@@ -22,7 +25,7 @@ pub trait Erased: std::any::Any + std::fmt::Debug {
     fn type_name(&self) -> &'static str;
 }
 
-impl<T: View> Erased for T {
+impl<T: View + ViewMarker> Erased for T {
     #[inline(always)]
     fn interests(&self) -> Interest {
         T::interests(self)

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -2,6 +2,7 @@ pub mod debug;
 pub mod helpers;
 
 mod state;
+pub(crate) use state::Debug;
 pub use state::{debug, DebugMode, State};
 
 mod response;

--- a/src/view/ui.rs
+++ b/src/view/ui.rs
@@ -1,7 +1,6 @@
-use std::cell::{Ref, RefCell};
-
 use crate::{
     layout::{Align2, Flex},
+    lock::{Lock, Ref, RefMapped},
     math::{Margin, Pos2, Rect, Size, Vec2},
     views::{self, Constrain},
     Border, Keybind, Rgba, Str,
@@ -16,7 +15,7 @@ pub struct Ui<'a> {
     nodes: &'a ViewNodes,
     layout: &'a LayoutNodes,
     input: &'a InputState,
-    palette: &'a RefCell<Palette>,
+    palette: &'a Lock<Palette>,
     client_rect: Rect,
 
     size_changed: Option<Vec2>,
@@ -110,12 +109,13 @@ impl<'a> Ui<'a> {
         self.nodes.current()
     }
 
-    pub fn children(&self) -> Ref<'_, [ViewId]> {
+    pub fn children(&self) -> RefMapped<'_, [ViewId]> {
         self.get_node_children(self.current()).unwrap()
     }
 
-    pub fn get_node_children(&self, id: ViewId) -> Option<Ref<'_, [ViewId]>> {
-        Some(Ref::map(self.nodes.get(id)?, |node| &*node.children))
+    pub fn get_node_children(&self, id: ViewId) -> Option<RefMapped<'_, [ViewId]>> {
+        let inner = self.nodes.get(id)?;
+        Some(RefMapped::map(inner, |node| &*node.children))
     }
 
     pub fn cursor_pos(&self) -> Pos2 {


### PR DESCRIPTION
This introduces an abstraction over `Rc`/`RefCell` and `Arc`/`parking_lot::RwLock`.

This is contained in the `lock` module which exposes:

| type | unsync (default) | sync|
| -- | -- | -- |
| `Lock<T>` | `RefCell<T>` | `parking_lot::RwLock<T>` |
| `Ref<T>` | `Ref<T>` | `parking_lot::RwLockReadGuard<T>` |
| `RefMut<T>` | `RefMut<T>` | `parking_lot::RwLockWriteGuard<T>` |
| `RefMapped<T>` | `Ref<T>` | `parking_lot::MappedRwLockReadGuard<T>` |
| `RefMutMapped<T>` | `RefMut<T>` | `parking_lot::MappedRwLockWriteGuard<T>` |
| `Shared<T>` | `Rc<T>` | `Arc<T>` |

note: `RefMapped` and `RefMutMapped` are not a type alias but rather new-type wrappers to match the behavior of **parking_lot**. So `Ref::map()` returns a `RefMapped` rather than a `Ref`

To opt-into _sync-ness_, use the optional feature flag `sync`

By default the **unsync** versions are used.